### PR TITLE
Add @captcha-libs/captchaai provider package (closes #28)

### DIFF
--- a/.changeset/add-captchaai.md
+++ b/.changeset/add-captchaai.md
@@ -1,0 +1,5 @@
+---
+"@captcha-libs/captchaai": minor
+---
+
+Add CaptchaAI provider client (reCAPTCHA v2/v3/Enterprise, Cloudflare Turnstile, image-to-text).

--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@
 [CapSolver](https://www.npmjs.com/package/@captcha-libs/capsolver)
 [CapGuru](https://www.npmjs.com/package/@captcha-libs/capguru)
 [2Captcha](https://www.npmjs.com/package/@captcha-libs/twocaptcha)
+[CaptchaAI](https://www.npmjs.com/package/@captcha-libs/captchaai)

--- a/packages/captchaai/CHANGELOG.md
+++ b/packages/captchaai/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @captcha-libs/captchaai

--- a/packages/captchaai/README.md
+++ b/packages/captchaai/README.md
@@ -1,0 +1,71 @@
+# CaptchaAI NodeJS captcha client - use CaptchaAI with ease
+[![Donate](https://img.shields.io/badge/Donate-PayPal-blue.svg)](https://www.paypal.com/paypalme/maxshydev)
+[![GitHub stars](https://img.shields.io/github/stars/blackravenx/captcha-libs.svg?style=social&label=Star)](https://github.com/blackravenx/captcha-libs)
+Docs: https://docs.captchaai.com
+
+## Installation
+* [npm](https://www.npmjs.com/package/@captcha-libs/captchaai)
+    ```$ npm i @captcha-libs/captchaai```
+* pnpm
+    ```$ pnpm i @captcha-libs/captchaai```
+* yarn
+    ```$ yarn add @captcha-libs/captchaai```
+
+### Usage
+```javascript
+//import CaptchaAI client and desired task
+import { CaptchaAI, RecaptchaV2TaskProxyless } from "@captcha-libs/captchaai";
+
+const captchaAIClient = new CaptchaAI({
+  clientKey: "<YOUR_CLIENT_KEY>",
+  pollingInterval: 5000, //optional. Delay in milliseconds to fetch task result, default: 5000ms
+  timeout: 120_000 //optional. Max time in milliseconds to wait for settled task result, default: 120000ms
+});
+
+//Pass captcha params to solve
+const reCaptchaV2Request = new RecaptchaV2TaskProxyless({
+  googlekey: "6LfD3PIbAAAAAJs_eEHvoOl75_83eXSqpPSRFJ_u",
+  pageurl: "https://captchaai.com/demo/recaptcha-v2"
+});
+
+//returns the solved token or throws an exception
+const reCaptchaV2Token = await captchaAIClient.solve(reCaptchaV2Request);
+
+//to get balance
+const balance = await captchaAIClient.getBalance()
+```
+### Usage with proxies
+```javascript
+const reCaptchaV2Request = new RecaptchaV2Task({
+  googlekey: "6LfD3PIbAAAAAJs_eEHvoOl75_83eXSqpPSRFJ_u",
+  pageurl: "https://captchaai.com/demo/recaptcha-v2",
+  //your proxy credentials
+  proxyAddress: "1.2.3.4", //required. string
+  proxyPort: 8080, //required. number
+  proxyType: "http", //required. 'http' or 'socks4' or 'socks5'
+  proxyLogin: "user", //optional. string
+  proxyPassword: "p4$$w0rd" //optional. string
+});
+
+```
+### Features
+* TypeScript-first design
+* Automatically waits for solution
+* Fully tested task payloads
+
+### Currently supported task payloads
+
+1. Classification:
+    * [ImageToTextTask](https://docs.captchaai.com)
+2. Token:
+    * [RecaptchaV2Task | RecaptchaV2TaskProxyless](https://docs.captchaai.com)
+    * [RecaptchaV2EnterpriseTask | RecaptchaV2EnterpriseTaskProxyless](https://docs.captchaai.com)
+    * [RecaptchaV3TaskProxyless](https://docs.captchaai.com)
+    * [TurnstileTask | TurnstileTaskProxyless](https://docs.captchaai.com)
+
+> Note: CaptchaAI does not solve hCaptcha, so hCaptcha is intentionally not part of this client.
+
+#### Looking for another captcha recognition service? Check our other libraries:
+* [CapSolver](https://www.npmjs.com/package/@captcha-libs/capsolver)
+* [CapGuru](https://www.npmjs.com/package/@captcha-libs/capguru)
+* [2Captcha](https://www.npmjs.com/package/@captcha-libs/twocaptcha)

--- a/packages/captchaai/eslint.config.js
+++ b/packages/captchaai/eslint.config.js
@@ -1,0 +1,4 @@
+import { baseConfig } from "@captcha-libs/eslint-config/base";
+
+/** @type {import('eslint').Linter.Config[]} */
+export default [ ...baseConfig ];

--- a/packages/captchaai/index.ts
+++ b/packages/captchaai/index.ts
@@ -1,0 +1,7 @@
+import { CaptchaAI } from "./src/lib/captchaai";
+
+export * from "./src/lib/Requests/Recognition";
+
+export * from "./src/lib/Requests/Token";
+
+export { CaptchaAI };

--- a/packages/captchaai/package.json
+++ b/packages/captchaai/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@captcha-libs/captchaai",
+  "version": "1.0.0",
+  "scripts": {
+    "lint": "eslint --config ./eslint.config.js --fix  --ignore-pattern '**/node_modules/**'  --ignore-pattern '**/dist/**'  --ignore-pattern '**/*.json/**' .",
+    "test": "vitest run .",
+    "build": "tsup"
+  },
+  "keywords": [
+    "CaptchaAI",
+    "Captcha recognition",
+    "Captcha solving",
+    "ReCaptcha captcha",
+    "ReCaptcha V2 captcha",
+    "ReCaptcha V3 captcha",
+    "ReCaptcha Enterprise captcha",
+    "Cloudflare captcha",
+    "Turnstile captcha",
+    "Image to text captcha"
+  ],
+  "license": "ISC",
+  "author": "Max Shy",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/blackravenx/captcha-libs.git",
+    "directory": "captchaai"
+  },
+  "dependencies": {
+    "@captcha-libs/captcha-client": "workspace:",
+    "node-fetch": "catalog:"
+  },
+  "devDependencies": {
+    "@captcha-libs/eslint-config": "workspace:^"
+  },
+  "description": "CaptchaAI NodeJS client, captcha recognition service",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
+  },
+  "files": [
+    "dist/"
+  ]
+}

--- a/packages/captchaai/src/lib/Requests/Recognition/ImageToTextTask.ts
+++ b/packages/captchaai/src/lib/Requests/Recognition/ImageToTextTask.ts
@@ -1,0 +1,99 @@
+import type { _IsTaskType } from "../_BaseTaskRequest";
+
+import { BaseTask, type BaseParams } from "../_BaseTaskRequest";
+
+export enum NumericOptions {
+  "none" = 0,
+  "onlyNumbers" = 1,
+  "onlyLetters" = 2,
+  "numbersOrLetters" = 3,
+  "numbersAndLetters" = 4
+}
+
+type ImageToTextParams = Omit<BaseParams, "type"> & {
+  "body": string;
+  "case"?: boolean;
+  "math"?: boolean;
+  "maxLength"?: number;
+  "minLength"?: number;
+  "numeric"?: NumericOptions;
+  "phrase"?: boolean;
+};
+
+/**
+ * Normal CAPTCHA is an image that contains distored but human-readable text. To solve the captcha user have to type the text from the image.
+ * @extends {BaseTask}
+ * @see {@link https://docs.captchaai.com}
+ */
+export class ImageToTextTask extends BaseTask implements _IsTaskType, ImageToTextParams {
+
+  /**
+   * @type {string} body - Image encoded into Base64 format. Data-URI format (containing data:content/type prefix) is also supported
+   */
+  body: string;
+
+  /**
+   * @type {string} case - Case sensitive or not
+   */
+  case?: boolean;
+
+  /**
+   * @type {string} math - Captcha requires calculation
+   */
+  math?: boolean;
+
+  /**
+   * @type {number} maxLength - defines maximal answer length
+   */
+  maxLength?: number;
+
+  /**
+   * @type {number} minLength - defines minimal answer length
+   */
+  minLength?: number;
+
+  /**
+   * @type {NumericOptions} numeric - Numeric preference
+   */
+  numeric?: NumericOptions;
+
+  /**
+   * @type {boolean} phrase - The answer should contain at least two words separated by space.
+   */
+  phrase?: boolean;
+
+  /**
+  * @type {boolean} _isImageToTextTask - Only used for correct method overloading intellisense
+  */
+  readonly _isImageToTextTask: _IsTaskType["_isImageToTextTask"] = true;
+
+  /**
+  * Create ImageToTextTask
+  * @see {@link https://docs.captchaai.com}
+  * @param {Object} params - ImageToTextParams
+  * @param {string} [params.body] - 	Image encoded into Base64 format. Data-URI format (containing data:content/type prefix) is also supported
+  * @param {boolean=} [params.case] - Case sensitive or not
+  * @param {boolean=} [params.math] - captcha requires calculation
+  * @param {number=} [params.maxLength] - defines maximal answer length
+  * @param {number=} [params.minLength] - defines minimal answer length
+  * @param {NumericOptions=} [params.numeric] - Numeric preference
+  * @param {boolean=} [params.phrase] - The answer should contain at least two words separated by space.
+  */
+  constructor ({ body, "case": _case, math, maxLength, minLength, numeric, phrase }: ImageToTextParams) {
+    super({ "type": "ImageToTextTask" }, "base64");
+
+    this.body = body;
+
+    this.case = _case;
+
+    this.math = math;
+
+    this.maxLength = maxLength;
+
+    this.minLength = minLength;
+
+    this.numeric = numeric;
+
+    this.phrase = phrase;
+  }
+}

--- a/packages/captchaai/src/lib/Requests/Recognition/index.ts
+++ b/packages/captchaai/src/lib/Requests/Recognition/index.ts
@@ -1,0 +1,3 @@
+import { ImageToTextTask } from "./ImageToTextTask";
+
+export { ImageToTextTask };

--- a/packages/captchaai/src/lib/Requests/Token/Base/_RecaptchaV2TaskBase.ts
+++ b/packages/captchaai/src/lib/Requests/Token/Base/_RecaptchaV2TaskBase.ts
@@ -1,0 +1,103 @@
+import type { ProxyCredentials, ProxyTypes, TaskTypes } from "../../_BaseTaskRequest";
+
+import { BaseTask } from "../../_BaseTaskRequest";
+
+export type RecaptchaV2TaskBaseParams = Partial<ProxyCredentials> & {
+  "cookies"?: string;
+  "domain"?: string;
+  "googlekey": string;
+  "invisible"?: boolean;
+  "pageurl": string;
+  "userAgent"?: string;
+};
+
+/**
+ * Base class for reCAPTCHA V2
+ * @extends {BaseTask}
+ * @see {@link https://docs.captchaai.com}
+ */
+export abstract class RecaptchaV2TaskBase extends BaseTask implements RecaptchaV2TaskBaseParams {
+
+  /**
+   * @type {string} cookies - Your cookies will be set in a browser of our worker. The format is: key1=val1; key2=val2
+   */
+  cookies?: string;
+
+  /**
+   * @type {string} domain - Domain used to load the captcha: google.com or recaptcha.net. Default value: google.com
+   */
+  domain?: string;
+
+  /**
+    * @type {boolean} invisible - Pass true for Invisible version of reCAPTCHA - a case when you don't see the checkbox, but the challenge appears. Mostly used with a callback function
+   */
+  invisible?: boolean;
+
+  /**
+   * @type {string} userAgent - User-Agent of your browser will be used to load the captcha. Use only modern browser's User-Agents
+   */
+  userAgent?: string;
+
+  /**
+   * @type {string} pageurl - The full URL of target web page where the captcha is loaded. We do not open the page, not a problem if it is available only for authenticated users
+   */
+  pageurl: string;
+
+  /**
+   * @type {string} googlekey - reCAPTCHA sitekey. Can be found inside data-sitekey property of the reCAPTCHA div element or inside k parameter of the requests to reCAPTHCHA API
+   */
+  googlekey: string;
+
+  proxyAddress?: string;
+
+  proxyLogin?: string;
+
+  proxyPassword?: string;
+
+  proxyPort?: number;
+
+  proxyType?: ProxyTypes;
+
+  /**
+  * RecaptchaV2TaskBase
+  * @see {@link https://docs.captchaai.com}
+  * @param {Object} params - RecaptchaV2TaskBaseParams
+  * @param {string} [params.pageurl] - The full URL of target web page where the captcha is loaded. We do not open the page, not a problem if it is available only for authenticated users
+  * @param {string} [params.googlekey] - reCAPTCHA sitekey. Can be found inside data-sitekey property of the reCAPTCHA div element or inside k parameter of the requests to reCAPTHCHA API
+  * @param {string} [params.userAgent] - User-Agent of your browser will be used to load the captcha. Use only modern browser's User-Agents
+  * @param {boolean}[params.invisible] - Pass true for Invisible version of reCAPTCHA - a case when you don't see the checkbox, but the challenge appears. Mostly used with a callback function
+  * @param {string} [params.domain] - Domain used to load the captcha: google.com or recaptcha.net. Default value: google.com
+  * @param {string} [params.cookies] - Your cookies will be set in a browser of our worker. The format is: key1=val1; key2=val2
+  * @param {string} [params.proxyAddress] -	Proxy IP address or hostname
+  * @param {string} [params.proxyLogin] - Login for basic authentication on the proxy
+  * @param {string} [params.proxyPassword] - Password for basic authentication on the proxy
+  * @param {string} [params.proxyType] - Type of your proxy: HTTP, HTTPS, SOCKS4, SOCKS5
+  * @param {string} [params.proxyPort] - Proxy port
+  *
+  */
+  constructor ({ googlekey, pageurl, userAgent, invisible, domain, cookies, proxyAddress, proxyPort, proxyType, proxyLogin, proxyPassword }: RecaptchaV2TaskBaseParams, type: TaskTypes) {
+    super({ type }, "userrecaptcha");
+
+    this.googlekey = googlekey;
+
+    this.pageurl = pageurl;
+
+    this.userAgent = userAgent;
+
+    this.invisible = invisible;
+
+    this.domain = domain;
+
+    this.cookies = cookies;
+
+    this.proxyAddress = proxyAddress;
+
+    this.proxyLogin = proxyLogin;
+
+    this.proxyPassword = proxyPassword;
+
+    this.proxyPort = proxyPort;
+
+    this.proxyType = proxyType;
+  }
+}

--- a/packages/captchaai/src/lib/Requests/Token/Base/_RecaptchaV3TaskBase.ts
+++ b/packages/captchaai/src/lib/Requests/Token/Base/_RecaptchaV3TaskBase.ts
@@ -1,0 +1,78 @@
+import type { TaskTypes } from "../../_BaseTaskRequest";
+
+import { BaseTask } from "../../_BaseTaskRequest";
+
+export type RecaptchaV3TaskBaseParams = {
+  "action"?: string;
+  "domain"?: string;
+  "googlekey": string;
+  "min_score"?: number;
+  "pageurl": string;
+  "version"?: string;
+};
+
+/**
+ * Base class for reCAPTCHA V3
+ * @extends {BaseTask}
+ * @see {@link https://docs.captchaai.com}
+ */
+export abstract class RecaptchaV3TaskBase extends BaseTask implements RecaptchaV3TaskBaseParams {
+
+  /**
+   * @type {string} domain - Domain used to load the captcha: google.com or recaptcha.net. Default value: google.com
+   */
+  domain?: string;
+
+  /**
+   * @type {string} pageurl - The full URL of target web page where the captcha is loaded. We do not open the page, not a problem if it is available only for authenticated users
+   */
+  pageurl: string;
+
+  /**
+   * @type {string} googlekey - reCAPTCHA sitekey. Can be found inside data-sitekey property of the reCAPTCHA div element or inside k parameter of the requests to reCAPTHCHA API
+   */
+  googlekey: string;
+
+  /**
+   * @type {string} version - reCAPTCHA version. Value is v3 for reCAPTCHA V3
+   */
+  version?: string;
+
+  /**
+   * @type {number} min_score - Required score value: 0.3, 0.7 or 0.9
+   */
+  min_score?: number;
+
+  /**
+   * @type {string} action - Action parameter value. The value is set by website owner inside data-action property of the reCAPTCHA div element or passed inside options object of execute method call, like grecaptcha.execute('googlekey'{ action: 'myAction' })
+   */
+  action?: string;
+
+  /**
+  * RecaptchaV3TaskBase
+  * @see {@link https://docs.captchaai.com}
+  * @param {Object} params - RecaptchaV3TaskBaseParams
+  * @param {string} [params.pageurl] - The full URL of target web page where the captcha is loaded. We do not open the page, not a problem if it is available only for authenticated users
+  * @param {string} [params.googlekey] - reCAPTCHA sitekey. Can be found inside data-sitekey property of the reCAPTCHA div element or inside k parameter of the requests to reCAPTHCHA API
+  * @param {string} [params.domain] - Domain used to load the captcha: google.com or recaptcha.net. Default value: google.com
+  * @param {string} [params.action] - Action parameter value. The value is set by website owner inside data-action property of the reCAPTCHA div element or passed inside options object of execute method call, like grecaptcha.execute('googlekey'{ action: 'myAction' })
+  * @param {number} [params.min_score] - Required score value: 0.3, 0.7 or 0.9
+  * @param {string} [params.version] - reCAPTCHA version. Value is v3 for reCAPTCHA V3
+  */
+  constructor ({ googlekey, pageurl, domain, min_score, action, version }: RecaptchaV3TaskBaseParams, type: TaskTypes) {
+    super({ type }, "userrecaptcha");
+
+    this.googlekey = googlekey;
+
+    this.pageurl = pageurl;
+
+    this.domain = domain;
+
+    this.min_score = min_score;
+
+    this.action = action;
+
+    this.version = version;
+  }
+
+}

--- a/packages/captchaai/src/lib/Requests/Token/Base/_TurnstileTaskBase.ts
+++ b/packages/captchaai/src/lib/Requests/Token/Base/_TurnstileTaskBase.ts
@@ -1,0 +1,101 @@
+import type { ProxyCredentials, ProxyTypes, TaskTypes } from "../../_BaseTaskRequest";
+
+import { BaseTask } from "../../_BaseTaskRequest";
+
+export type TurnstileTaskBaseParams = Partial<ProxyCredentials> & {
+  "action"?: string;
+  "data"?: string;
+  "pagedata"?: string;
+  "pageurl": string;
+  "sitekey": string;
+  "userAgent"?: string;
+};
+
+/**
+ * Base class for TurnstileTask
+ * @extends {BaseTask}
+ * @see {@link https://docs.captchaai.com}
+ */
+export abstract class TurnstileTaskBase extends BaseTask implements TurnstileTaskBaseParams {
+
+  /**
+   * @type {string} pageurl - The full URL of target web page where the captcha is loaded. We do not open the page, not a problem if it is available only for authenticated users
+   */
+  pageurl: string;
+
+  /**
+   * @type {string} sitekey - Turnstile sitekey. Can be found inside data-sitekey property of the Turnstile div element
+   */
+  sitekey: string;
+
+  /**
+   * @type {string} action - Required for Cloudflare Challenge pages. The value of action parameter of turnstile.render call
+   */
+  action?: string;
+
+  /**
+   * @type {string} data - Required for Cloudflare Challenge pages. The value of cData parameter of turnstile.render call
+   */
+  data?: string;
+
+  /**
+   * @type {string} pagedata - Required for Cloudflare Challenge pages. The value of chlPageData parameter of turnstile.render call
+   */
+  pagedata?: string;
+
+  /**
+   * @type {string} userAgent - User-Agent of your browser will be used to load the captcha. Use only modern browser's User-Agents
+   */
+  userAgent?: string;
+
+  proxyAddress?: string;
+
+  proxyLogin?: string;
+
+  proxyPassword?: string;
+
+  proxyPort?: number;
+
+  proxyType?: ProxyTypes;
+
+  /**
+  * TurnstileTaskBase
+  * @see {@link https://docs.captchaai.com}
+  * @param {Object} params - TurnstileTaskParams
+  * @param {string} [params.pageurl] - The full URL of target web page where the captcha is loaded. We do not open the page, not a problem if it is available only for authenticated users
+  * @param {string} [params.sitekey] - Turnstile sitekey. Can be found inside data-sitekey property of the Turnstile div element
+  * @param {string} [params.action] - Required for Cloudflare Challenge pages. The value of action parameter of turnstile.render call
+  * @param {string} [params.data] - Required for Cloudflare Challenge pages. The value of cData parameter of turnstile.render call
+  * @param {string} [params.pagedata] - Required for Cloudflare Challenge pages. The value of chlPageData parameter of turnstile.render call
+  * @param {string} [params.proxyAddress] -	Proxy IP address or hostname
+  * @param {string} [params.proxyLogin] - Login for basic authentication on the proxy
+  * @param {string} [params.proxyPassword] - Password for basic authentication on the proxy
+  * @param {string} [params.proxyType] - Type of your proxy: HTTP, HTTPS, SOCKS4, SOCKS5
+  * @param {string} [params.proxyPort] - Proxy port
+  */
+  constructor ({ sitekey, pageurl, proxyAddress, proxyPort, proxyType, proxyLogin, proxyPassword, userAgent, pagedata, data, action }: TurnstileTaskBaseParams, type: TaskTypes) {
+    super({ type }, "turnstile");
+
+    this.sitekey = sitekey;
+
+    this.pageurl = pageurl;
+
+    this.proxyAddress = proxyAddress;
+
+    this.proxyLogin = proxyLogin;
+
+    this.proxyPassword = proxyPassword;
+
+    this.proxyPort = proxyPort;
+
+    this.proxyType = proxyType;
+
+    this.userAgent = userAgent;
+
+    this.action = action;
+
+    this.pagedata = pagedata;
+
+    this.data = data;
+  }
+}

--- a/packages/captchaai/src/lib/Requests/Token/RecaptchaV2EnterpriseTask.ts
+++ b/packages/captchaai/src/lib/Requests/Token/RecaptchaV2EnterpriseTask.ts
@@ -1,0 +1,51 @@
+import type { ProxyRequiredTaskParams, _IsTaskType } from "../_BaseTaskRequest";
+
+import type { RecaptchaV2TaskBaseParams } from "./Base/_RecaptchaV2TaskBase";
+
+import { RecaptchaV2TaskBase } from "./Base/_RecaptchaV2TaskBase";
+
+export interface _RecaptchaV2EnterpriseTaskParams { "enterprisePayload"?: Record<string, string> }
+
+type RecaptchaV2EnterpriseTaskParams = _RecaptchaV2EnterpriseTaskParams & ProxyRequiredTaskParams<RecaptchaV2TaskBaseParams>;
+
+/**
+ * Token-based method for automated solving of reCAPTCHA V2 Enterprise.
+ * @extends {RecaptchaV2TaskBase}
+ * @see {@link https://docs.captchaai.com}
+ */
+export class RecaptchaV2EnterpriseTask extends RecaptchaV2TaskBase implements _RecaptchaV2EnterpriseTaskParams, _IsTaskType {
+
+  /**
+  * @type {boolean} _isRecaptchaV2EnterpriseTask - Only used for correct method overloading intellisense
+  */
+  readonly _isRecaptchaV2EnterpriseTask: _IsTaskType["_isRecaptchaV2EnterpriseTask"] = true;
+
+  /**
+   * @type {string} enterprisePayload - Additional parameters passed to grecaptcha.enterprise.render call. For example, there can be an object containing s value
+   */
+  enterprisePayload?: Record<string, string>;
+
+  /**
+  * Create RecaptchaV2EnterpriseTask
+  * @see {@link https://docs.captchaai.com}
+  * @param {Object} params - RecaptchaV2EnterpriseTaskParams
+  * @param {string} [params.pageurl] - The full URL of target web page where the captcha is loaded. We do not open the page, not a problem if it is available only for authenticated users
+  * @param {string} [params.googlekey] - reCAPTCHA sitekey. Can be found inside data-sitekey property of the reCAPTCHA div element or inside k parameter of the requests to reCAPTHCHA API
+  * @param {string} [params.userAgent] - User-Agent of your browser will be used to load the captcha. Use only modern browser's User-Agents
+  * @param {boolean}[params.invisible] - Pass true for Invisible version of reCAPTCHA - a case when you don't see the checkbox, but the challenge appears. Mostly used with a callback function
+  * @param {string} [params.enterprisePayload] - Additional parameters passed to grecaptcha.enterprise.render call. For example, there can be an object containing s value
+  * @param {string} [params.domain] - Domain used to load the captcha: google.com or recaptcha.net. Default value: google.com
+  * @param {string} [params.cookies] - Your cookies will be set in a browser of our worker. The format is: key1=val1; key2=val2
+  * @param {string} [params.proxyAddress] -	Proxy IP address or hostname
+  * @param {string} [params.proxyLogin] - Login for basic authentication on the proxy
+  * @param {string} [params.proxyPassword] - Password for basic authentication on the proxy
+  * @param {string} [params.proxyType] - Type of your proxy: HTTP, HTTPS, SOCKS4, SOCKS5
+  * @param {string} [params.proxyPort] - Proxy port
+  *
+  */
+  constructor ({ enterprisePayload, ...params }: RecaptchaV2EnterpriseTaskParams) {
+    super(params, "RecaptchaV2EnterpriseTask");
+
+    this.enterprisePayload = enterprisePayload;
+  }
+}

--- a/packages/captchaai/src/lib/Requests/Token/RecaptchaV2EnterpriseTaskProxyless.ts
+++ b/packages/captchaai/src/lib/Requests/Token/RecaptchaV2EnterpriseTaskProxyless.ts
@@ -1,0 +1,42 @@
+import type { ProxylessTaskParams, _IsTaskType } from "../_BaseTaskRequest";
+
+import type { _RecaptchaV2EnterpriseTaskParams } from "./RecaptchaV2EnterpriseTask";
+
+import type { RecaptchaV2TaskBaseParams } from "./Base/_RecaptchaV2TaskBase";
+
+import { RecaptchaV2TaskBase } from "./Base/_RecaptchaV2TaskBase";
+
+type RecaptchaV2EnterpriseTaskProxylessParams = _RecaptchaV2EnterpriseTaskParams & ProxylessTaskParams<RecaptchaV2TaskBaseParams>;
+
+/**
+ * Token-based method for automated solving of reCAPTCHA V2 Enterprise.
+ * @extends {RecaptchaV2TaskBase}
+ * @see {@link https://docs.captchaai.com}
+ */
+export class RecaptchaV2EnterpriseTaskProxyless extends RecaptchaV2TaskBase implements _RecaptchaV2EnterpriseTaskParams, _IsTaskType {
+
+  /**
+  * @type {boolean} _isRecaptchaV2EnterpriseTaskProxyless - Only used for correct method overloading intellisense
+  */
+  readonly _isRecaptchaV2EnterpriseTaskProxyless: _IsTaskType["_isRecaptchaV2EnterpriseTaskProxyless"] = true;
+
+  enterprisePayload?: Record<string, string>;
+
+  /**
+  * Create RecaptchaV2EnterpriseTaskProxyless
+  * @see {@link https://docs.captchaai.com}
+  * @param {Object} params - RecaptchaV2EnterpriseTaskProxylessParams
+  * @param {string} [params.pageurl] - The full URL of target web page where the captcha is loaded. We do not open the page, not a problem if it is available only for authenticated users
+  * @param {string} [params.googlekey] - reCAPTCHA sitekey. Can be found inside data-sitekey property of the reCAPTCHA div element or inside k parameter of the requests to reCAPTHCHA API
+  * @param {string} [params.userAgent] - User-Agent of your browser will be used to load the captcha. Use only modern browser's User-Agents
+  * @param {boolean}[params.invisible] - Pass true for Invisible version of reCAPTCHA - a case when you don't see the checkbox, but the challenge appears. Mostly used with a callback function
+  * @param {string} [params.enterprisePayload] - Additional parameters passed to grecaptcha.enterprise.render call. For example, there can be an object containing s value
+  * @param {string} [params.domain] - Domain used to load the captcha: google.com or recaptcha.net. Default value: google.com
+  * @param {string} [params.cookies] - Your cookies will be set in a browser of our worker. The format is: key1=val1; key2=val2
+  */
+  constructor ({ enterprisePayload, ...params }: RecaptchaV2EnterpriseTaskProxylessParams) {
+    super(params, "RecaptchaV2EnterpriseTaskProxyless");
+
+    this.enterprisePayload = enterprisePayload;
+  }
+}

--- a/packages/captchaai/src/lib/Requests/Token/RecaptchaV2Task.ts
+++ b/packages/captchaai/src/lib/Requests/Token/RecaptchaV2Task.ts
@@ -1,0 +1,43 @@
+import type { _IsTaskType } from "./../_BaseTaskRequest";
+
+import type { ProxyRequiredTaskParams } from "../_BaseTaskRequest";
+
+import type { RecaptchaV2TaskBaseParams } from "./Base/_RecaptchaV2TaskBase";
+
+import { RecaptchaV2TaskBase } from "./Base/_RecaptchaV2TaskBase";
+
+type RecaptchaV2TaskParams = ProxyRequiredTaskParams<RecaptchaV2TaskBaseParams>;
+
+/**
+ * Token-based method for automated solving of reCAPTCHA V2.
+ * @extends {RecaptchaV2TaskBase}
+ * @see {@link https://docs.captchaai.com}
+ */
+export class RecaptchaV2Task extends RecaptchaV2TaskBase implements _IsTaskType {
+
+  /**
+  * @type {boolean} _isRecaptchaV2Task - Only used for correct method overloading intellisense
+  */
+  readonly _isRecaptchaV2Task: _IsTaskType["_isRecaptchaV2Task"] = true;
+
+  /**
+  * Create RecaptchaV2Task
+  * @see {@link https://docs.captchaai.com}
+  * @param {Object} params - RecaptchaV2TaskParams
+  * @param {string} [params.pageurl] - The full URL of target web page where the captcha is loaded. We do not open the page, not a problem if it is available only for authenticated users
+  * @param {string} [params.googlekey] - reCAPTCHA sitekey. Can be found inside data-sitekey property of the reCAPTCHA div element or inside k parameter of the requests to reCAPTHCHA API
+  * @param {string} [params.userAgent] - User-Agent of your browser will be used to load the captcha. Use only modern browser's User-Agents
+  * @param {boolean}[params.invisible] - Pass true for Invisible version of reCAPTCHA - a case when you don't see the checkbox, but the challenge appears. Mostly used with a callback function
+  * @param {string} [params.domain] - Domain used to load the captcha: google.com or recaptcha.net. Default value: google.com
+  * @param {string} [params.cookies] - Your cookies will be set in a browser of our worker. The format is: key1=val1; key2=val2
+  * @param {string} [params.proxyAddress] -	Proxy IP address or hostname
+  * @param {string} [params.proxyLogin] - Login for basic authentication on the proxy
+  * @param {string} [params.proxyPassword] - Password for basic authentication on the proxy
+  * @param {string} [params.proxyType] - Type of your proxy: HTTP, HTTPS, SOCKS4, SOCKS5
+  * @param {string} [params.proxyPort] - Proxy port
+  *
+  */
+  constructor (params: RecaptchaV2TaskParams) {
+    super(params, "RecaptchaV2Task");
+  }
+}

--- a/packages/captchaai/src/lib/Requests/Token/RecaptchaV2TaskProxyless.ts
+++ b/packages/captchaai/src/lib/Requests/Token/RecaptchaV2TaskProxyless.ts
@@ -1,0 +1,35 @@
+import type { ProxylessTaskParams, _IsTaskType } from "../_BaseTaskRequest";
+
+import { RecaptchaV2TaskBase } from "./Base/_RecaptchaV2TaskBase";
+
+import type { RecaptchaV2TaskBaseParams } from "./Base/_RecaptchaV2TaskBase";
+
+type RecaptchaV2TaskProxylessParams = ProxylessTaskParams<RecaptchaV2TaskBaseParams>;
+
+/**
+ * Token-based method for automated solving of reCAPTCHA V2.
+ * @extends {RecaptchaV2TaskProxylessBase}
+ * @see {@link https://docs.captchaai.com}
+ */
+export class RecaptchaV2TaskProxyless extends RecaptchaV2TaskBase implements _IsTaskType {
+
+  /**
+  * @type {boolean} _isRecaptchaV2TaskProxyless - Only used for correct method overloading intellisense
+  */
+  readonly _isRecaptchaV2TaskProxyless: _IsTaskType["_isRecaptchaV2TaskProxyless"] = true;
+
+  /**
+  * Create RecaptchaV2TaskProxyless
+  * @see {@link https://docs.captchaai.com}
+  * @param {Object} params - RecaptchaV2TaskProxylessParams
+  * @param {string} [params.pageurl] - The full URL of target web page where the captcha is loaded. We do not open the page, not a problem if it is available only for authenticated users
+  * @param {string} [params.googlekey] - reCAPTCHA sitekey. Can be found inside data-sitekey property of the reCAPTCHA div element or inside k parameter of the requests to reCAPTHCHA API
+  * @param {string} [params.userAgent] - User-Agent of your browser will be used to load the captcha. Use only modern browser's User-Agents
+  * @param {boolean}[params.invisible] - Pass true for Invisible version of reCAPTCHA - a case when you don't see the checkbox, but the challenge appears. Mostly used with a callback function
+  * @param {string} [params.domain] - Domain used to load the captcha: google.com or recaptcha.net. Default value: google.com
+  * @param {string} [params.cookies] - Your cookies will be set in a browser of our worker. The format is: key1=val1; key2=val2
+  */
+  constructor (params: RecaptchaV2TaskProxylessParams) {
+    super(params, "RecaptchaV2TaskProxyless");
+  }
+}

--- a/packages/captchaai/src/lib/Requests/Token/RecaptchaV3TaskProxyless.ts
+++ b/packages/captchaai/src/lib/Requests/Token/RecaptchaV3TaskProxyless.ts
@@ -1,0 +1,38 @@
+import type { ProxylessTaskParams, _IsTaskType } from "../_BaseTaskRequest";
+
+import type { RecaptchaV3TaskBaseParams } from "./Base/_RecaptchaV3TaskBase";
+
+import { RecaptchaV3TaskBase } from "./Base/_RecaptchaV3TaskBase";
+
+type RecaptchaV3TaskProxylessParams = ProxylessTaskParams<RecaptchaV3TaskBaseParams>;
+
+/**
+ * Token-based method for automated solving of reCAPTCHA V3.
+ * @extends {RecaptchaV3TaskBase}
+ * @see {@link https://docs.captchaai.com}
+ */
+export class RecaptchaV3TaskProxyless extends RecaptchaV3TaskBase implements _IsTaskType {
+
+  /**
+  * @type {boolean} _isRecaptchaV3TaskProxyless - Only used for correct method overloading intellisense
+  */
+  readonly _isRecaptchaV3TaskProxyless: _IsTaskType["_isRecaptchaV3TaskProxyless"] = true;
+
+  /**
+  * Create RecaptchaV3TaskProxyless
+  * @see {@link https://docs.captchaai.com}
+  * @param {Object} params - RecaptchaV3TaskProxylessParams
+  * @param {string} [params.pageurl] - The full URL of target web page where the captcha is loaded. We do not open the page, not a problem if it is available only for authenticated users
+  * @param {string} [params.googlekey] - reCAPTCHA sitekey. Can be found inside data-sitekey property of the reCAPTCHA div element or inside k parameter of the requests to reCAPTHCHA API
+  * @param {string} [params.domain] - Domain used to load the captcha: google.com or recaptcha.net. Default value: google.com
+  * @param {string} [params.action] - Action parameter value. The value is set by website owner inside data-action property of the reCAPTCHA div element or passed inside options object of execute method call, like grecaptcha.execute('googlekey'{ action: 'myAction' })
+  * @param {number} [params.min_score] - Required score value: 0.3, 0.7 or 0.9
+  * @param {string} [params.version] - reCAPTCHA version. Value is v3 for reCAPTCHA V3
+  */
+  constructor (params: RecaptchaV3TaskProxylessParams) {
+    super({
+      "version": "v3",
+      ...params
+    }, "RecaptchaV3TaskProxyless");
+  }
+}

--- a/packages/captchaai/src/lib/Requests/Token/TurnstileTask.ts
+++ b/packages/captchaai/src/lib/Requests/Token/TurnstileTask.ts
@@ -1,0 +1,39 @@
+import type { ProxyRequiredTaskParams, _IsTaskType } from "../_BaseTaskRequest";
+
+import type { TurnstileTaskBaseParams } from "./Base/_TurnstileTaskBase";
+
+import { TurnstileTaskBase } from "./Base/_TurnstileTaskBase";
+
+type TurnstileTaskParams = ProxyRequiredTaskParams<TurnstileTaskBaseParams>;
+
+/**
+ * Token-based method to bypass Cloudflare Turnstile. Both the standalone captcha and challenge mode are supported.
+ * @extends {TurnstileTaskBase}
+ * @see {@link https://docs.captchaai.com}
+ */
+export class TurnstileTask extends TurnstileTaskBase implements _IsTaskType {
+
+  /**
+  * @type {boolean} _isTurnstileTask - Only used for correct method overloading intellisense
+  */
+  readonly _isTurnstileTask: _IsTaskType["_isTurnstileTask"] = true;
+
+  /**
+  * Create TurnstileTask
+  * @see {@link https://docs.captchaai.com}
+  * @param {Object} params - TurnstileTaskParams
+  * @param {string} [params.pageurl] - The full URL of target web page where the captcha is loaded. We do not open the page, not a problem if it is available only for authenticated users
+  * @param {string} [params.sitekey] - Turnstile sitekey. Can be found inside data-sitekey property of the Turnstile div element
+  * @param {string} [params.action] - Required for Cloudflare Challenge pages. The value of action parameter of turnstile.render call
+  * @param {string} [params.data] - Required for Cloudflare Challenge pages. The value of cData parameter of turnstile.render call
+  * @param {string} [params.pagedata] - Required for Cloudflare Challenge pages. The value of chlPageData parameter of turnstile.render call
+  * @param {string} [params.proxyAddress] -	Proxy IP address or hostname
+  * @param {string} [params.proxyLogin] - Login for basic authentication on the proxy
+  * @param {string} [params.proxyPassword] - Password for basic authentication on the proxy
+  * @param {string} [params.proxyType] - Type of your proxy: HTTP, HTTPS, SOCKS4, SOCKS5
+  * @param {string} [params.proxyPort] - Proxy port
+  */
+  constructor (params: TurnstileTaskParams) {
+    super(params, "TurnstileTask");
+  }
+}

--- a/packages/captchaai/src/lib/Requests/Token/TurnstileTaskProxyless.ts
+++ b/packages/captchaai/src/lib/Requests/Token/TurnstileTaskProxyless.ts
@@ -1,0 +1,34 @@
+import type { ProxylessTaskParams, _IsTaskType } from "../_BaseTaskRequest";
+
+import type { TurnstileTaskBaseParams } from "./Base/_TurnstileTaskBase";
+
+import { TurnstileTaskBase } from "./Base/_TurnstileTaskBase";
+
+type TurnstileTaskProxylessParams = ProxylessTaskParams<TurnstileTaskBaseParams>;
+
+/**
+ * Token-based method to bypass Cloudflare Turnstile. Both the standalone captcha and challenge mode are supported.
+ * @extends {TurnstileTaskBase}
+ * @see {@link https://docs.captchaai.com}
+ */
+export class TurnstileTaskProxyless extends TurnstileTaskBase implements _IsTaskType {
+
+  /**
+  * @type {boolean} _isTurnstileTaskProxyless - Only used for correct method overloading intellisense
+  */
+  readonly _isTurnstileTaskProxyless: _IsTaskType["_isTurnstileTaskProxyless"] = true;
+
+  /**
+  * Create TurnstileTaskProxyless
+  * @see {@link https://docs.captchaai.com}
+  * @param {Object} params - TurnstileTaskProxylessParams
+  * @param {string} [params.pageurl] - The full URL of target web page where the captcha is loaded. We do not open the page, not a problem if it is available only for authenticated users
+  * @param {string} [params.sitekey] - Turnstile sitekey. Can be found inside data-sitekey property of the Turnstile div element
+  * @param {string} [params.action] - Required for Cloudflare Challenge pages. The value of action parameter of turnstile.render call
+  * @param {string} [params.data] - Required for Cloudflare Challenge pages. The value of cData parameter of turnstile.render call
+  * @param {string} [params.pagedata] - Required for Cloudflare Challenge pages. The value of chlPageData parameter of turnstile.render call
+  */
+  constructor (params: TurnstileTaskProxylessParams) {
+    super(params, "TurnstileTaskProxyless");
+  }
+}

--- a/packages/captchaai/src/lib/Requests/Token/index.ts
+++ b/packages/captchaai/src/lib/Requests/Token/index.ts
@@ -1,0 +1,23 @@
+import { TurnstileTaskProxyless } from "./TurnstileTaskProxyless";
+
+import { TurnstileTask } from "./TurnstileTask";
+
+import { RecaptchaV3TaskProxyless } from "./RecaptchaV3TaskProxyless";
+
+import { RecaptchaV2EnterpriseTaskProxyless } from "./RecaptchaV2EnterpriseTaskProxyless";
+
+import { RecaptchaV2EnterpriseTask } from "./RecaptchaV2EnterpriseTask";
+
+import { RecaptchaV2TaskProxyless } from "./RecaptchaV2TaskProxyless";
+
+import { RecaptchaV2Task } from "./RecaptchaV2Task";
+
+export {
+  RecaptchaV2Task,
+  RecaptchaV2TaskProxyless,
+  RecaptchaV2EnterpriseTask,
+  RecaptchaV2EnterpriseTaskProxyless,
+  RecaptchaV3TaskProxyless,
+  TurnstileTask,
+  TurnstileTaskProxyless
+};

--- a/packages/captchaai/src/lib/Requests/_BaseTaskRequest.ts
+++ b/packages/captchaai/src/lib/Requests/_BaseTaskRequest.ts
@@ -1,0 +1,62 @@
+const _TaskTypes = [
+  "ImageToTextTask",
+  "RecaptchaV2TaskProxyless",
+  "RecaptchaV2Task",
+  "RecaptchaV2EnterpriseTask",
+  "RecaptchaV2EnterpriseTaskProxyless",
+  "RecaptchaV3TaskProxyless",
+  "TurnstileTask",
+  "TurnstileTaskProxyless"
+] as const;
+
+export type TaskTypes = typeof _TaskTypes[number];
+
+/**
+ * @type {WireMethods} WireMethods - CaptchaAI in.php `method` param values
+ * @see {@link https://docs.captchaai.com}
+ */
+export type WireMethods = "base64" | "turnstile" | "userrecaptcha";
+
+export interface BaseParams { "type": TaskTypes }
+
+export type ProxyTypes = "http" | "socks4" | "socks5";
+
+export type ProxyCredentials = {
+  "proxyAddress": string;
+  "proxyLogin"?: string;
+  "proxyPassword"?: string;
+  "proxyPort": number;
+  "proxyType": ProxyTypes;
+};
+
+export type ProxyRequiredTaskParams<T> = ProxyCredentials & T;
+
+export type ProxylessTaskParams<T> = Omit<T, keyof ProxyCredentials>;
+
+/**
+ * @type {_IsTaskType} _IsTaskType - Only used for correct method overloading intellisense
+ */
+export type _IsTaskType = { readonly [type in TaskTypes as `_is${type}`]?: boolean };
+
+//
+// @classdesc BaseTask for CaptchaAI tasks
+// @class
+//
+export abstract class BaseTask {
+
+  /**
+  * @type {TaskTypes} type - task type
+  */
+  protected type: TaskTypes;
+
+  /**
+  * @type {WireMethods} method - CaptchaAI in.php `method` param value
+  */
+  protected method: WireMethods;
+
+  constructor ({ type }: BaseParams, method: WireMethods) {
+    this.type = type;
+
+    this.method = method;
+  }
+}

--- a/packages/captchaai/src/lib/Requests/index.ts
+++ b/packages/captchaai/src/lib/Requests/index.ts
@@ -1,0 +1,9 @@
+import type { ImageToTextTask } from "./Recognition";
+
+import type { RecaptchaV2EnterpriseTask, RecaptchaV2EnterpriseTaskProxyless, RecaptchaV2Task, RecaptchaV2TaskProxyless, RecaptchaV3TaskProxyless, TurnstileTask, TurnstileTaskProxyless } from "./Token";
+
+export type Requests = ImageToTextTask | RecaptchaV2EnterpriseTask | RecaptchaV2EnterpriseTaskProxyless | RecaptchaV2Task | RecaptchaV2TaskProxyless | RecaptchaV3TaskProxyless | TurnstileTask | TurnstileTaskProxyless;
+
+export * from "./Token";
+
+export * from "./Recognition";

--- a/packages/captchaai/src/lib/Solutions/Recognition/ImageToTextTaskSolution.ts
+++ b/packages/captchaai/src/lib/Solutions/Recognition/ImageToTextTaskSolution.ts
@@ -1,0 +1,5 @@
+/**
+ * @see {@link https://docs.captchaai.com}
+ * The recognized text returned as the res.php `request` value.
+ */
+export type ImageToTextTaskSolution = string;

--- a/packages/captchaai/src/lib/Solutions/Recognition/index.ts
+++ b/packages/captchaai/src/lib/Solutions/Recognition/index.ts
@@ -1,0 +1,3 @@
+import { ImageToTextTaskSolution } from "./ImageToTextTaskSolution";
+
+export { ImageToTextTaskSolution };

--- a/packages/captchaai/src/lib/Solutions/Token/RecaptchaV2TaskSolution.ts
+++ b/packages/captchaai/src/lib/Solutions/Token/RecaptchaV2TaskSolution.ts
@@ -1,0 +1,5 @@
+/**
+ * @see {@link https://docs.captchaai.com}
+ * The reCAPTCHA V2 token (g-recaptcha-response) returned as the res.php `request` value.
+ */
+export type RecaptchaV2TaskSolution = string;

--- a/packages/captchaai/src/lib/Solutions/Token/RecaptchaV3TaskSolution.ts
+++ b/packages/captchaai/src/lib/Solutions/Token/RecaptchaV3TaskSolution.ts
@@ -1,0 +1,5 @@
+/**
+ * @see {@link https://docs.captchaai.com}
+ * The reCAPTCHA V3 token (g-recaptcha-response) returned as the res.php `request` value.
+ */
+export type RecaptchaV3TaskSolution = string;

--- a/packages/captchaai/src/lib/Solutions/Token/TurnstileTaskSolution.ts
+++ b/packages/captchaai/src/lib/Solutions/Token/TurnstileTaskSolution.ts
@@ -1,0 +1,5 @@
+/**
+ * @see {@link https://docs.captchaai.com}
+ * The Cloudflare Turnstile token returned as the res.php `request` value.
+ */
+export type TurnstileTaskSolution = string;

--- a/packages/captchaai/src/lib/Solutions/Token/index.ts
+++ b/packages/captchaai/src/lib/Solutions/Token/index.ts
@@ -1,0 +1,11 @@
+import { TurnstileTaskSolution } from "./TurnstileTaskSolution";
+
+import { RecaptchaV3TaskSolution } from "./RecaptchaV3TaskSolution";
+
+import { RecaptchaV2TaskSolution } from "./RecaptchaV2TaskSolution";
+
+export {
+  RecaptchaV2TaskSolution,
+  RecaptchaV3TaskSolution,
+  TurnstileTaskSolution
+};

--- a/packages/captchaai/src/lib/Solutions/_BaseSolution.ts
+++ b/packages/captchaai/src/lib/Solutions/_BaseSolution.ts
@@ -1,0 +1,10 @@
+import type { CaptchaAISolution } from "../types";
+
+/**
+ * @see {@link https://docs.captchaai.com}
+ * CaptchaAI res.php success solution. `request` holds the solved token or text,
+ * `status` is 1 on success.
+ */
+export type CaptchaAISuccessSolution = CaptchaAISolution;
+
+export type { CaptchaAISolution };

--- a/packages/captchaai/src/lib/Solutions/index.ts
+++ b/packages/captchaai/src/lib/Solutions/index.ts
@@ -1,0 +1,3 @@
+export * from "./Token";
+
+export * from "./Recognition";

--- a/packages/captchaai/src/lib/captchaai.ts
+++ b/packages/captchaai/src/lib/captchaai.ts
@@ -1,0 +1,202 @@
+import { CaptchaClient, delay } from "@captcha-libs/captcha-client";
+
+import type { CaptchaClientParams, CaptchaAICreateTaskResponse, CaptchaAIBalanceResponse, CaptchaAISolution } from "./types";
+
+import type {
+  ImageToTextTask,
+  RecaptchaV2EnterpriseTask,
+  RecaptchaV2EnterpriseTaskProxyless,
+  RecaptchaV2Task,
+  RecaptchaV2TaskProxyless,
+  RecaptchaV3TaskProxyless,
+  Requests,
+  TurnstileTask,
+  TurnstileTaskProxyless
+} from "./Requests";
+
+import type {
+  ImageToTextTaskSolution,
+  RecaptchaV2TaskSolution,
+  RecaptchaV3TaskSolution,
+  TurnstileTaskSolution
+} from "./Solutions";
+
+import fetch, { AbortError } from "node-fetch";
+
+/**
+ * @classdesc CaptchaAI client
+ * @class
+ * @see {@link https://docs.captchaai.com}
+ */
+export class CaptchaAI extends CaptchaClient<CaptchaAICreateTaskResponse, Requests> {
+
+  /**
+   * @type {string} clientKey - YOUR_API_KEY from dashboard
+   */
+  protected clientKey: string;
+
+  /**
+   * @type {number} pollingInterval - polling interval to getTaskResult in ms. Default to 5000
+   */
+  protected pollingInterval: number;
+
+  /**
+   * @type {number} timeout - max timeout to getTaskResult in ms. Default to 120_000
+   */
+  protected timeout: number;
+
+  /**
+   * @type {string} baseUrl - api base url
+   */
+  protected baseUrl: string = "https://ocr.captchaai.com";
+
+  /**
+   * @param {object} [params] - CaptchaClientParams
+   * @param {string} [params.clientKey] - YOUR_API_KEY from dashboard
+   * @param {number} [params.timeout] - max timeout to getTaskResult
+   * @param {number} [params.pollingInterval] - polling interval to getTaskResult
+   */
+  constructor (params: CaptchaClientParams) {
+    const { clientKey, timeout = 120_000, pollingInterval = 5_000 } = params;
+
+    super();
+
+    this.clientKey = clientKey;
+
+    this.pollingInterval = pollingInterval;
+
+    this.timeout = timeout;
+  }
+
+  /**
+   * Flattens a task payload into in.php form params, dropping internal discriminant flags.
+   * @param {Requests} request - task payload
+   * @return {URLSearchParams} - form encoded params
+   */
+  private toFormParams (request: Requests): URLSearchParams {
+    const params = new URLSearchParams({
+      "key": this.clientKey,
+      "json": "1"
+    });
+
+    for (const [
+      key,
+      value
+    ] of Object.entries(request)) {
+      if (key.startsWith("_is") || key === "type") continue;
+
+      if (value === undefined || value === null) continue;
+
+      if (typeof value === "boolean") params.append(key, value
+        ? "1"
+        : "0");
+      else if (typeof value === "object") params.append(key, JSON.stringify(value));
+      else params.append(key, String(value));
+    }
+
+    return params;
+  }
+
+  public async getBalance (): Promise<number> {
+    const params = new URLSearchParams({
+      "key": this.clientKey,
+      "action": "getbalance",
+      "json": "1"
+    });
+
+    const body = await fetch(`${this.baseUrl}/res.php?${params.toString()}`, { "method": "GET" });
+
+    const response = await body.json() as CaptchaAIBalanceResponse;
+
+    if (response.status !== 1) throw new Error(`CaptchaAI: ${response.request}`);
+
+    return Number(response.request);
+  }
+
+  /**
+   * @param {Requests} request - task payload to create task
+   * @return {Promise<CaptchaAICreateTaskResponse>} - response of createTask
+   */
+  protected async createTask (request: Requests): Promise<CaptchaAICreateTaskResponse> {
+    const body = await fetch(`${this.baseUrl}/in.php`, {
+      "body": this.toFormParams(request),
+      "method": "POST"
+    });
+
+    const response = await body.json() as CaptchaAICreateTaskResponse;
+
+    if (response.status !== 1) throw new Error(`CaptchaAI: ${response.request}`);
+
+    return response;
+  }
+
+  /**
+  * @param {ImageToTextTask} request - task payload to create ImageToTextTask
+  * @see {@link https://docs.captchaai.com}
+  * @return {Promise<ImageToTextTaskSolution>} - solved captcha text
+  */
+  public async solve (request: ImageToTextTask): Promise<ImageToTextTaskSolution>;
+
+  /**
+  * @param {RecaptchaV2EnterpriseTask | RecaptchaV2EnterpriseTaskProxyless | RecaptchaV2Task | RecaptchaV2TaskProxyless} request - task payload to create RecaptchaV2 task
+  * @see {@link https://docs.captchaai.com}
+  * @return {Promise<RecaptchaV2TaskSolution>} - solved reCAPTCHA V2 token
+  */
+  public async solve (request: RecaptchaV2EnterpriseTask | RecaptchaV2EnterpriseTaskProxyless | RecaptchaV2Task | RecaptchaV2TaskProxyless): Promise<RecaptchaV2TaskSolution>;
+
+  /**
+  * @param {RecaptchaV3TaskProxyless} request - task payload to create RecaptchaV3TaskProxyless
+  * @see {@link https://docs.captchaai.com}
+  * @return {Promise<RecaptchaV3TaskSolution>} - solved reCAPTCHA V3 token
+  */
+  public async solve (request: RecaptchaV3TaskProxyless): Promise<RecaptchaV3TaskSolution>;
+
+  /**
+  * @param {TurnstileTask | TurnstileTaskProxyless} request - task payload to create TurnstileTask or TurnstileTaskProxyless
+  * @see {@link https://docs.captchaai.com}
+  * @return {Promise<TurnstileTaskSolution>} - solved Cloudflare Turnstile token
+  */
+  public async solve (request: TurnstileTask | TurnstileTaskProxyless): Promise<TurnstileTaskSolution>;
+
+  /**
+  * @param {Requests} request - task payload to create task or taskProxyless
+  * @return {Promise<string>} - solved captcha token or text
+  */
+  public async solve (request: Requests): Promise<string> {
+    const balance = await this.getBalance();
+
+    if (!balance) throw new Error("CaptchaAI: ERROR_ZERO_BALANCE");
+
+    const createTaskResponse = await this.createTask(request);
+
+    const abortSignal = AbortSignal.timeout(this.timeout);
+
+    const params = new URLSearchParams({
+      "key": this.clientKey,
+      "action": "get",
+      "id": createTaskResponse.request,
+      "json": "1"
+    });
+
+    try {
+      while (!abortSignal.aborted) {
+        const body = await fetch(`${this.baseUrl}/res.php?${params.toString()}`, {
+          "method": "GET",
+          "signal": abortSignal
+        });
+
+        const response = await body.json() as CaptchaAISolution;
+
+        if (response.status === 1) return response.request;
+        else if (response.request !== "CAPCHA_NOT_READY") throw new Error(`CaptchaAI: ${response.request}`);
+
+        await delay(this.pollingInterval);
+      }
+    } catch (error) {
+      if (error instanceof AbortError && error.name === "AbortError") throw new Error(`CaptchaAI timeout ${this.timeout} exceeded!`);
+      else throw error;
+    }
+
+    throw new Error("CaptchaAI finished with error");
+  }
+}

--- a/packages/captchaai/src/lib/types.ts
+++ b/packages/captchaai/src/lib/types.ts
@@ -1,0 +1,40 @@
+export interface CaptchaClientParams {
+  "clientKey": string;
+  "pollingInterval"?: number;
+  "timeout"?: number;
+}
+
+/**
+ * @see {@link https://docs.captchaai.com}
+ * Raw response of a CaptchaAI in.php / res.php request when `json=1` is passed.
+ * `status` is 1 on success, 0 otherwise. `request` holds the id, token or error code.
+ */
+export interface CaptchaAIResponse {
+  "request": string;
+  "status": number;
+}
+
+/**
+ * Successful in.php submit response. `request` holds the created captcha id.
+ */
+export interface CaptchaAICreateTaskResponse {
+  "request": string;
+  "status": number;
+}
+
+/**
+ * Successful getbalance response. `request` holds the balance as a string.
+ */
+export interface CaptchaAIBalanceResponse {
+  "request": string;
+  "status": number;
+}
+
+/**
+ * res.php poll response. `status` 1 = solved (`request` holds the token/text),
+ * `status` 0 with request CAPCHA_NOT_READY = still pending, any other request value = terminal error.
+ */
+export interface CaptchaAISolution {
+  "request": string;
+  "status": number;
+}

--- a/packages/captchaai/src/tests/Requests/Recognition/ImageToTextTask.spec.ts
+++ b/packages/captchaai/src/tests/Requests/Recognition/ImageToTextTask.spec.ts
@@ -1,0 +1,47 @@
+import { ImageToTextTask, NumericOptions } from "../../../lib/Requests/Recognition/ImageToTextTask";
+
+import { expect, it, describe } from "vitest";
+
+describe("ImageToTextTask", () => {
+  it("To be equal to object", () => {
+    const task = new ImageToTextTask({
+      "body": "some-body",
+      "case": true,
+      "math": true,
+      "maxLength": 10,
+      "minLength": 9,
+      "numeric": NumericOptions.numbersAndLetters,
+      "phrase": true
+    });
+
+    expect(task).toEqual({
+      "_isImageToTextTask": true,
+      "body": "some-body",
+      "case": true,
+      "math": true,
+      "maxLength": 10,
+      "method": "base64",
+      "minLength": 9,
+      "numeric": NumericOptions.numbersAndLetters,
+      "phrase": true,
+      "type": "ImageToTextTask"
+    });
+  });
+
+  it("To be equal to object without optional params", () => {
+    const task = new ImageToTextTask({ "body": "some-body" });
+
+    expect(task).toEqual({
+      "_isImageToTextTask": true,
+      "body": "some-body",
+      "case": undefined,
+      "math": undefined,
+      "maxLength": undefined,
+      "method": "base64",
+      "minLength": undefined,
+      "numeric": undefined,
+      "phrase": undefined,
+      "type": "ImageToTextTask"
+    });
+  });
+});

--- a/packages/captchaai/src/tests/Requests/Token/RecaptchaV2EnterpriseTask.spec.ts
+++ b/packages/captchaai/src/tests/Requests/Token/RecaptchaV2EnterpriseTask.spec.ts
@@ -1,0 +1,68 @@
+import { RecaptchaV2EnterpriseTask } from "../../../lib/Requests/Token/RecaptchaV2EnterpriseTask";
+
+import { expect, it, describe } from "vitest";
+
+describe("RecaptchaV2EnterpriseTask", () => {
+  it("To be equal to object", () => {
+    const task = new RecaptchaV2EnterpriseTask({
+      "cookies": "some-cookies",
+      "domain": "some-domain",
+      "enterprisePayload": { "s": "some-s" },
+      "googlekey": "some-googlekey",
+      "invisible": false,
+      "pageurl": "some-pageurl",
+      "proxyAddress": "some-proxyAddress",
+      "proxyLogin": "some-proxyLogin",
+      "proxyPassword": "some-proxyPassword",
+      "proxyPort": 1010,
+      "proxyType": "http",
+      "userAgent": "some-userAgent"
+    });
+
+    expect(task).toEqual({
+      "_isRecaptchaV2EnterpriseTask": true,
+      "cookies": "some-cookies",
+      "domain": "some-domain",
+      "enterprisePayload": { "s": "some-s" },
+      "googlekey": "some-googlekey",
+      "invisible": false,
+      "method": "userrecaptcha",
+      "pageurl": "some-pageurl",
+      "proxyAddress": "some-proxyAddress",
+      "proxyLogin": "some-proxyLogin",
+      "proxyPassword": "some-proxyPassword",
+      "proxyPort": 1010,
+      "proxyType": "http",
+      "type": "RecaptchaV2EnterpriseTask",
+      "userAgent": "some-userAgent"
+    });
+  });
+
+  it("To be equal to object without optional params", () => {
+    const task = new RecaptchaV2EnterpriseTask({
+      "googlekey": "some-googlekey",
+      "pageurl": "some-pageurl",
+      "proxyAddress": "some-proxyAddress",
+      "proxyPort": 1010,
+      "proxyType": "http"
+    });
+
+    expect(task).toEqual({
+      "_isRecaptchaV2EnterpriseTask": true,
+      "cookies": undefined,
+      "domain": undefined,
+      "enterprisePayload": undefined,
+      "googlekey": "some-googlekey",
+      "invisible": undefined,
+      "method": "userrecaptcha",
+      "pageurl": "some-pageurl",
+      "proxyAddress": "some-proxyAddress",
+      "proxyLogin": undefined,
+      "proxyPassword": undefined,
+      "proxyPort": 1010,
+      "proxyType": "http",
+      "type": "RecaptchaV2EnterpriseTask",
+      "userAgent": undefined
+    });
+  });
+});

--- a/packages/captchaai/src/tests/Requests/Token/RecaptchaV2EnterpriseTaskProxyless.spec.ts
+++ b/packages/captchaai/src/tests/Requests/Token/RecaptchaV2EnterpriseTaskProxyless.spec.ts
@@ -1,0 +1,60 @@
+import { RecaptchaV2EnterpriseTaskProxyless } from "../../../lib/Requests/Token/RecaptchaV2EnterpriseTaskProxyless";
+
+import { expect, it, describe } from "vitest";
+
+describe("RecaptchaV2EnterpriseTaskProxyless", () => {
+  it("To be equal to object", () => {
+    const task = new RecaptchaV2EnterpriseTaskProxyless({
+      "cookies": "some-cookies",
+      "domain": "some-domain",
+      "enterprisePayload": { "s": "some-s" },
+      "googlekey": "some-googlekey",
+      "invisible": false,
+      "pageurl": "some-pageurl",
+      "userAgent": "some-userAgent"
+    });
+
+    expect(task).toEqual({
+      "_isRecaptchaV2EnterpriseTaskProxyless": true,
+      "cookies": "some-cookies",
+      "domain": "some-domain",
+      "enterprisePayload": { "s": "some-s" },
+      "googlekey": "some-googlekey",
+      "invisible": false,
+      "method": "userrecaptcha",
+      "pageurl": "some-pageurl",
+      "proxyAddress": undefined,
+      "proxyLogin": undefined,
+      "proxyPassword": undefined,
+      "proxyPort": undefined,
+      "proxyType": undefined,
+      "type": "RecaptchaV2EnterpriseTaskProxyless",
+      "userAgent": "some-userAgent"
+    });
+  });
+
+  it("To be equal to object without optional params", () => {
+    const task = new RecaptchaV2EnterpriseTaskProxyless({
+      "googlekey": "some-googlekey",
+      "pageurl": "some-pageurl"
+    });
+
+    expect(task).toEqual({
+      "_isRecaptchaV2EnterpriseTaskProxyless": true,
+      "cookies": undefined,
+      "domain": undefined,
+      "enterprisePayload": undefined,
+      "googlekey": "some-googlekey",
+      "invisible": undefined,
+      "method": "userrecaptcha",
+      "pageurl": "some-pageurl",
+      "proxyAddress": undefined,
+      "proxyLogin": undefined,
+      "proxyPassword": undefined,
+      "proxyPort": undefined,
+      "proxyType": undefined,
+      "type": "RecaptchaV2EnterpriseTaskProxyless",
+      "userAgent": undefined
+    });
+  });
+});

--- a/packages/captchaai/src/tests/Requests/Token/RecaptchaV2Task.spec.ts
+++ b/packages/captchaai/src/tests/Requests/Token/RecaptchaV2Task.spec.ts
@@ -1,0 +1,66 @@
+import { RecaptchaV2Task } from "../../../lib/Requests/Token/RecaptchaV2Task";
+
+import { expect, it, describe } from "vitest";
+
+describe("RecaptchaV2Task", () => {
+  it("To be equal to object", () => {
+    const task = new RecaptchaV2Task({
+      "cookies": "some-cookies",
+      "domain": "some-domain",
+      "googlekey": "some-googlekey",
+      "invisible": false,
+      "pageurl": "some-pageurl",
+      "proxyAddress": "some-proxyAddress",
+      "proxyLogin": "some-proxyLogin",
+      "proxyPassword": "some-proxyPassword",
+      "proxyPort": 1010,
+      "proxyType": "http",
+      "userAgent": "some-userAgent"
+    });
+
+    expect(task).toEqual({
+      "_isRecaptchaV2Task": true,
+      "cookies": "some-cookies",
+      "domain": "some-domain",
+      "googlekey": "some-googlekey",
+      "invisible": false,
+      "method": "userrecaptcha",
+      "pageurl": "some-pageurl",
+      "proxyAddress": "some-proxyAddress",
+      "proxyLogin": "some-proxyLogin",
+      "proxyPassword": "some-proxyPassword",
+      "proxyPort": 1010,
+      "proxyType": "http",
+      "type": "RecaptchaV2Task",
+      "userAgent": "some-userAgent"
+    });
+  });
+
+  it("To be equal to object without optional params", () => {
+    const task = new RecaptchaV2Task({
+      "googlekey": "some-googlekey",
+      "pageurl": "some-pageurl",
+      "proxyAddress": "some-proxyAddress",
+      "proxyPort": 1010,
+      "proxyType": "http",
+      "userAgent": "some-userAgent"
+    });
+
+    expect(task).toEqual({
+      "_isRecaptchaV2Task": true,
+      "cookies": undefined,
+      "domain": undefined,
+      "googlekey": "some-googlekey",
+      "invisible": undefined,
+      "method": "userrecaptcha",
+      "pageurl": "some-pageurl",
+      "proxyAddress": "some-proxyAddress",
+      "proxyLogin": undefined,
+      "proxyPassword": undefined,
+      "proxyPort": 1010,
+      "proxyType": "http",
+      "type": "RecaptchaV2Task",
+      "userAgent": "some-userAgent"
+    });
+  });
+});

--- a/packages/captchaai/src/tests/Requests/Token/RecaptchaV2TaskProxyless.spec.ts
+++ b/packages/captchaai/src/tests/Requests/Token/RecaptchaV2TaskProxyless.spec.ts
@@ -1,0 +1,58 @@
+import { RecaptchaV2TaskProxyless } from "../../../lib/Requests/Token/RecaptchaV2TaskProxyless";
+
+import { expect, it, describe } from "vitest";
+
+describe("RecaptchaV2TaskProxyless", () => {
+  it("To be equal to object", () => {
+    const task = new RecaptchaV2TaskProxyless({
+      "cookies": "some-cookies",
+      "domain": "some-domain",
+      "googlekey": "some-googlekey",
+      "invisible": false,
+      "pageurl": "some-pageurl",
+      "userAgent": "some-userAgent"
+    });
+
+    expect(task).toEqual({
+      "_isRecaptchaV2TaskProxyless": true,
+      "cookies": "some-cookies",
+      "domain": "some-domain",
+      "googlekey": "some-googlekey",
+      "invisible": false,
+      "method": "userrecaptcha",
+      "pageurl": "some-pageurl",
+      "proxyAddress": undefined,
+      "proxyLogin": undefined,
+      "proxyPassword": undefined,
+      "proxyPort": undefined,
+      "proxyType": undefined,
+      "type": "RecaptchaV2TaskProxyless",
+      "userAgent": "some-userAgent"
+    });
+  });
+
+  it("To be equal to object without optional params", () => {
+    const task = new RecaptchaV2TaskProxyless({
+      "googlekey": "some-googlekey",
+      "pageurl": "some-pageurl",
+      "userAgent": "some-userAgent"
+    });
+
+    expect(task).toEqual({
+      "_isRecaptchaV2TaskProxyless": true,
+      "cookies": undefined,
+      "domain": undefined,
+      "googlekey": "some-googlekey",
+      "invisible": undefined,
+      "method": "userrecaptcha",
+      "pageurl": "some-pageurl",
+      "proxyAddress": undefined,
+      "proxyLogin": undefined,
+      "proxyPassword": undefined,
+      "proxyPort": undefined,
+      "proxyType": undefined,
+      "type": "RecaptchaV2TaskProxyless",
+      "userAgent": "some-userAgent"
+    });
+  });
+});

--- a/packages/captchaai/src/tests/Requests/Token/RecaptchaV3TaskProxyless.spec.ts
+++ b/packages/captchaai/src/tests/Requests/Token/RecaptchaV3TaskProxyless.spec.ts
@@ -1,0 +1,46 @@
+import { RecaptchaV3TaskProxyless } from "../../../lib/Requests/Token/RecaptchaV3TaskProxyless";
+
+import { expect, it, describe } from "vitest";
+
+describe("RecaptchaV3TaskProxyless", () => {
+  it("To be equal to object", () => {
+    const task = new RecaptchaV3TaskProxyless({
+      "action": "some-action",
+      "domain": "some-domain",
+      "googlekey": "some-googlekey",
+      "min_score": 0.3,
+      "pageurl": "some-pageurl"
+    });
+
+    expect(task).toEqual({
+      "_isRecaptchaV3TaskProxyless": true,
+      "action": "some-action",
+      "domain": "some-domain",
+      "googlekey": "some-googlekey",
+      "method": "userrecaptcha",
+      "min_score": 0.3,
+      "pageurl": "some-pageurl",
+      "type": "RecaptchaV3TaskProxyless",
+      "version": "v3"
+    });
+  });
+
+  it("To be equal to object without optional params", () => {
+    const task = new RecaptchaV3TaskProxyless({
+      "googlekey": "some-googlekey",
+      "pageurl": "some-pageurl"
+    });
+
+    expect(task).toEqual({
+      "_isRecaptchaV3TaskProxyless": true,
+      "action": undefined,
+      "domain": undefined,
+      "googlekey": "some-googlekey",
+      "method": "userrecaptcha",
+      "min_score": undefined,
+      "pageurl": "some-pageurl",
+      "type": "RecaptchaV3TaskProxyless",
+      "version": "v3"
+    });
+  });
+});

--- a/packages/captchaai/src/tests/Requests/Token/TurnstileTask.spec.ts
+++ b/packages/captchaai/src/tests/Requests/Token/TurnstileTask.spec.ts
@@ -1,0 +1,65 @@
+import { TurnstileTask } from "../../../lib/Requests/Token/TurnstileTask";
+
+import { expect, it, describe } from "vitest";
+
+describe("TurnstileTask", () => {
+  it("To be equal to object", () => {
+    const task = new TurnstileTask({
+      "action": "some-action",
+      "data": "some-data",
+      "pagedata": "some-pagedata",
+      "pageurl": "some-pageurl",
+      "proxyAddress": "some-proxyAddress",
+      "proxyLogin": "some-proxyLogin",
+      "proxyPassword": "some-proxyPassword",
+      "proxyPort": 1010,
+      "proxyType": "http",
+      "sitekey": "some-sitekey",
+      "userAgent": "some-userAgent"
+    });
+
+    expect(task).toEqual({
+      "_isTurnstileTask": true,
+      "action": "some-action",
+      "data": "some-data",
+      "method": "turnstile",
+      "pagedata": "some-pagedata",
+      "pageurl": "some-pageurl",
+      "proxyAddress": "some-proxyAddress",
+      "proxyLogin": "some-proxyLogin",
+      "proxyPassword": "some-proxyPassword",
+      "proxyPort": 1010,
+      "proxyType": "http",
+      "sitekey": "some-sitekey",
+      "type": "TurnstileTask",
+      "userAgent": "some-userAgent"
+    });
+  });
+
+  it("To be equal to object without optional params", () => {
+    const task = new TurnstileTask({
+      "pageurl": "some-pageurl",
+      "proxyAddress": "some-proxyAddress",
+      "proxyPort": 1010,
+      "proxyType": "http",
+      "sitekey": "some-sitekey"
+    });
+
+    expect(task).toEqual({
+      "_isTurnstileTask": true,
+      "action": undefined,
+      "data": undefined,
+      "method": "turnstile",
+      "pagedata": undefined,
+      "pageurl": "some-pageurl",
+      "proxyAddress": "some-proxyAddress",
+      "proxyLogin": undefined,
+      "proxyPassword": undefined,
+      "proxyPort": 1010,
+      "proxyType": "http",
+      "sitekey": "some-sitekey",
+      "type": "TurnstileTask",
+      "userAgent": undefined
+    });
+  });
+});

--- a/packages/captchaai/src/tests/Requests/Token/TurnstileTaskProxyless.spec.ts
+++ b/packages/captchaai/src/tests/Requests/Token/TurnstileTaskProxyless.spec.ts
@@ -1,0 +1,57 @@
+import { TurnstileTaskProxyless } from "../../../lib/Requests/Token/TurnstileTaskProxyless";
+
+import { expect, it, describe } from "vitest";
+
+describe("TurnstileTaskProxyless", () => {
+  it("To be equal to object", () => {
+    const task = new TurnstileTaskProxyless({
+      "action": "some-action",
+      "data": "some-data",
+      "pagedata": "some-pagedata",
+      "pageurl": "some-pageurl",
+      "sitekey": "some-sitekey",
+      "userAgent": "some-userAgent"
+    });
+
+    expect(task).toEqual({
+      "_isTurnstileTaskProxyless": true,
+      "action": "some-action",
+      "data": "some-data",
+      "method": "turnstile",
+      "pagedata": "some-pagedata",
+      "pageurl": "some-pageurl",
+      "proxyAddress": undefined,
+      "proxyLogin": undefined,
+      "proxyPassword": undefined,
+      "proxyPort": undefined,
+      "proxyType": undefined,
+      "sitekey": "some-sitekey",
+      "type": "TurnstileTaskProxyless",
+      "userAgent": "some-userAgent"
+    });
+  });
+
+  it("To be equal to object without optional params", () => {
+    const task = new TurnstileTaskProxyless({
+      "pageurl": "some-pageurl",
+      "sitekey": "some-sitekey"
+    });
+
+    expect(task).toEqual({
+      "_isTurnstileTaskProxyless": true,
+      "action": undefined,
+      "data": undefined,
+      "method": "turnstile",
+      "pagedata": undefined,
+      "pageurl": "some-pageurl",
+      "proxyAddress": undefined,
+      "proxyLogin": undefined,
+      "proxyPassword": undefined,
+      "proxyPort": undefined,
+      "proxyType": undefined,
+      "sitekey": "some-sitekey",
+      "type": "TurnstileTaskProxyless",
+      "userAgent": undefined
+    });
+  });
+});

--- a/packages/captchaai/tsconfig.json
+++ b/packages/captchaai/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": false,
+    "emitDeclarationOnly": false,
+    "incremental": false,
+    "esModuleInterop": true,
+    "baseUrl": "./",
+    "rootDir": "."
+  },
+  "files": [],
+  "include": ["index.ts", "src/**/*.ts"], 
+  "exclude": ["node_modules", "coverage", "dist", "**/*.test.ts", "**/*.spec.ts", "vitest.config.ts", "./src/tests/**/.ts"],
+  "references": []
+}

--- a/packages/captchaai/tsconfig.lib.json
+++ b/packages/captchaai/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"],
+    "composite": true
+  },
+  "include": ["src/**/*.ts", "index.ts"],
+  "exclude": ["vitest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/captchaai/tsconfig.spec.json
+++ b/packages/captchaai/tsconfig.spec.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["node"],
+    "composite": true,
+    "declaration": true
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts",
+    "./src/tests/**/*.ts",
+    "./src/lib/**/*.ts",
+  ]
+}

--- a/packages/captchaai/tsup.config.ts
+++ b/packages/captchaai/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  "entry": [ "./index.ts" ],
+  "format": [
+    "cjs",
+    "esm"
+  ],
+  "dts": true,
+  "splitting": true,
+  "sourcemap": true,
+  "clean": true,
+  "minify": false,
+  "outDir": "dist",
+  "noExternal": [ "@captcha-libs/captcha-client" ]
+});

--- a/packages/captchaai/vitest.config.ts
+++ b/packages/captchaai/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+import preset from "../../vitest.config";
+
+export default defineConfig({
+  ...preset,
+  "test": {
+    ...preset.test,
+    "coverage": { "reportsDirectory": "./coverage" }
+  }
+});

--- a/packages/twocaptcha/README.md
+++ b/packages/twocaptcha/README.md
@@ -112,3 +112,4 @@ What 'custom' does mean? Custom means that the parameters and solutions have bee
 #### Looking for another captcha recognition service? Check our other libraries: 
 * [CapSolver](https://www.npmjs.com/package/@captcha-libs/capsolver)
 * [CapGuru](https://www.npmjs.com/package/@captcha-libs/capguru)
+* [CaptchaAI](https://www.npmjs.com/package/@captcha-libs/captchaai)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    node-fetch:
+      specifier: ^3.3.2
+      version: 3.3.2
+
 importers:
 
   .:
@@ -96,6 +102,19 @@ importers:
       eslint:
         specifier: 8.57.0
         version: 8.57.0
+
+  packages/captchaai:
+    dependencies:
+      '@captcha-libs/captcha-client':
+        specifier: 'workspace:'
+        version: link:../captcha-client
+      node-fetch:
+        specifier: 'catalog:'
+        version: 3.3.2
+    devDependencies:
+      '@captcha-libs/eslint-config':
+        specifier: workspace:^
+        version: link:../../tooling/eslint-config
 
   packages/twocaptcha:
     dependencies:
@@ -2224,6 +2243,7 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}


### PR DESCRIPTION
Hi @blackravenx — as invited in #28, this adds a **`@captcha-libs/captchaai`** provider package, following the same per-package structure as `twocaptcha` / `capsolver`.

### What''s included
- New package `packages/captchaai/` with the client (`CaptchaAI extends CaptchaClient`), Task classes, Solutions, vitest specs, and configs mirroring the existing providers.
- Supported captcha types: **reCAPTCHA v2, v3, Enterprise, Cloudflare Turnstile, and image-to-text.**
- Added to the root README "Currently supported services" list + a changeset.

### One design note (worth a look)
CaptchaAI''s public API is the **classic 2Captcha form protocol** (`POST /in.php` → poll `GET /res.php`, base `https://ocr.captchaai.com`), not the modern `createTask`/`getTaskResult` JSON API the other packages use. So the package keeps the same **class/method surface** (`.solve()`, per-captcha Task classes, `.getBalance()`) but implements that transport internally — analogous to how `capsolver` diverges on its own `baseUrl`. Two consequences:
- `solve()` returns the token/text **string** directly (the legacy protocol returns a bare token, not a rich solution object).
- **hCaptcha is intentionally omitted** — CaptchaAI doesn''t solve it, so it''s excluded from the types/overloads rather than stubbed.

### Verification
- `pnpm --filter @captcha-libs/captchaai test` → **16 tests / 8 files pass**
- `pnpm --filter @captcha-libs/captchaai build` → **ESM + CJS + DTS build success**
- No regressions — the other packages still build/test/lint.

Happy to adjust naming, structure, or the `solve()` return convention to match your preferences. Thanks for the invite!

(Separately, on your affiliate/referral question in #28 — yes, we have one; our partnerships team will reach out to get you set up so it stays off the public thread.)